### PR TITLE
update keyring repos now on CRAN

### DIFF
--- a/content/best-practices/managing-credentials.Rmd
+++ b/content/best-practices/managing-credentials.Rmd
@@ -54,15 +54,20 @@ con <- DBI::dbConnect(odbc::odbc(),
 
 ## Encrypt credentials with `keyring`
 
-The [keyring](https://github.com/gaborcsardi/keyring) package uses the operating system's credential storage. It currently supports:
+The [keyring](https://github.com/r-lib/keyring) package uses the operating system's credential storage. It currently supports:
 
 - Keychain on MacOS
 - Credential Store on Windows
 - the Secret Service API on Linux
 
-
+You can now install from CRAN
 ```{r, eval = FALSE}
-devtools::install_github("gaborcsardi/keyring")
+install.packages("keyring")
+```
+
+or the dev version from github
+```{r, eval = FALSE}
+devtools::install_github("r-lib/keyring")
 ```
 
 ### Keyrings and keys


### PR DESCRIPTION
As I trying to work with `keyring`, I saw that documentation is not up-to-date now that the repo has moved and package is on CRAN now. 

If you want to update, I am glad to help. If not, just close this PR. 

Thanks for your new website ! And congrats because is really beautiful ! Nice theme!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rstudio/db.rstudio.com/39)
<!-- Reviewable:end -->
