### PR TITLE
Small spelling fix on snippets page

### DIFF
--- a/content/advanced/snippets.Rmd
+++ b/content/advanced/snippets.Rmd
@@ -42,7 +42,7 @@ data[data$mpg == ${0:Miles per Gallon=21.4} | data$cyl == ${1:Cylinders=6}, ]
 
 <img src="resources/connections/fields-connection-interface.png" width="300" style="display: inline-block;margin: 0 auto;"/>
 
-In order to craete a `;` separated list of values, one can use the syntax `${Position:Label=Default:Key}`. Semicolon-separated list are common in database connections and therefore, natevely supported in snippet files, for instance:
+In order to create a `;` separated list of values, one can use the syntax `${Position:Label=Default:Key}`. Semicolon-separated list are common in database connections and therefore, natevely supported in snippet files, for instance:
 
 ```r
 "${2:Letters=ABC:LettersKey}${3:Numbers=123:NumbersKey}"

--- a/content/advanced/snippets.Rmd
+++ b/content/advanced/snippets.Rmd
@@ -42,7 +42,7 @@ data[data$mpg == ${0:Miles per Gallon=21.4} | data$cyl == ${1:Cylinders=6}, ]
 
 <img src="resources/connections/fields-connection-interface.png" width="300" style="display: inline-block;margin: 0 auto;"/>
 
-In order to create a `;` separated list of values, one can use the syntax `${Position:Label=Default:Key}`. Semicolon-separated list are common in database connections and therefore, natevely supported in snippet files, for instance:
+In order to create a `;` separated list of values, one can use the syntax `${Position:Label=Default:Key}`. Semicolon-separated list are common in database connections and therefore, natively supported in snippet files, for instance:
 
 ```r
 "${2:Letters=ABC:LettersKey}${3:Numbers=123:NumbersKey}"
@@ -69,7 +69,7 @@ You can integrate with RStudio's Connection Pane to allow users to explore conne
 
 ### Snippet Files
 
-Snippet Files are specified under the `/inst/rstudio/connections` and follow the same syntax mentioend in the "Snippet Files" section.
+Snippet Files are specified under the `/inst/rstudio/connections` and follow the same syntax mentioned in the "Snippet Files" section.
 
 ### Shiny Application
 

--- a/content/advanced/snippets.html
+++ b/content/advanced/snippets.html
@@ -34,7 +34,7 @@ data &lt;- read_csv(readr_example(&quot;mtcars.csv&quot;))</code></pre>
 data &lt;- read_csv(readr_example(&quot;mtcars.csv&quot;))
 data[data$mpg == ${0:Miles per Gallon=21.4} | data$cyl == ${1:Cylinders=6}, ]</code></pre>
 <p><img src="resources/connections/fields-connection-interface.png" width="300" style="display: inline-block;margin: 0 auto;"/></p>
-<p>In order to craete a <code>;</code> separated list of values, one can use the syntax <code>${Position:Label=Default:Key}</code>. Semicolon-separated list are common in database connections and therefore, natevely supported in snippet files, for instance:</p>
+<p>In order to create a <code>;</code> separated list of values, one can use the syntax <code>${Position:Label=Default:Key}</code>. Semicolon-separated list are common in database connections and therefore, natevely supported in snippet files, for instance:</p>
 <pre class="r"><code>&quot;${2:Letters=ABC:LettersKey}${3:Numbers=123:NumbersKey}&quot;</code></pre>
 <p><img src="resources/connections/keyvalue-connection-interface.png" width="300" style="display: inline-block;margin: 0 auto;"/></p>
 <p>There are a couple escape characters supported: <code>$colon$</code> to escape <code>:</code> and <code>$equal</code> to escape <code>=</code>.</p>


### PR DESCRIPTION
Fixed a small spelling error on the snippets page: craete -> create