### PR TITLE
Fix MacOS DB connections setup link to reference the appropriate sub-section

### DIFF
--- a/content/best-practices/drivers.Rmd
+++ b/content/best-practices/drivers.Rmd
@@ -53,7 +53,7 @@ application is used to manage ODBC data sources on Windows.
 
 ### Setting up database connections
 
-See the section with the same name in the [Linux section](/drivers/#linux-debian-ubuntu).
+See the section with the same name in the [Linux section](/best-practices/drivers/#setting-up-database-connections-1).
 
 ## Linux Debian / Ubuntu
 

--- a/content/best-practices/drivers.html
+++ b/content/best-practices/drivers.html
@@ -52,7 +52,7 @@ application is used to manage ODBC data sources on Windows.</p>
 </div>
 <div id="setting-up-database-connections" class="section level3">
 <h3>Setting up database connections</h3>
-<p>See the section with the same name in the <a href="/drivers/#linux-debian-ubuntu">Linux section</a>.</p>
+<p>See the section with the same name in the <a href="/best-practices/drivers/#setting-up-database-connections-1">Linux section</a>.</p>
 </div>
 </div>
 <div id="linux-debian-ubuntu" class="section level2">


### PR DESCRIPTION
The "Setting up database connections" link for MacOS that points to the "Linux section" was broken.