### PR TITLE
Update managing-credentials.Rmd

### DIFF
--- a/content/best-practices/managing-credentials.Rmd
+++ b/content/best-practices/managing-credentials.Rmd
@@ -107,7 +107,7 @@ keyring::key_list("my-database")[1,2]
 To extract the `password`, use `key_get()`:
 
 ```{r}
-keyring::key_get("my-database")
+keyring::key_get("my-database", "myusername")
 ```
 
 These functions can be used to supply the database credentials without storing them in plain text or an environment variable:
@@ -119,7 +119,7 @@ con <- dbConnect(odbc::odbc(),
   Port     = 1433,
   Database = "default",
   UID      = keyring::key_list("my-database")[1,2],
-  PWD      = keyring::key_get("my-database"))
+  PWD      = keyring::key_get("my-database", "myusername"))
 ```
 
 The default keyring is unlocked anytime the user is signed in. If a new keyring is created and used, the Operating System will prompt the user for the `keyring` password when the code executes.


### PR DESCRIPTION
When you run key_get() with just the database input you get an error, adding the username resolves this error.