### PR TITLE
updated Google Analytics tracking number 

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseurl = "/"
+baseurl = "https://db.rstudio.com/"
 languageCode = "en-us"
 title = "Databases using R"
 theme = "rstudio-docs-theme"
@@ -7,7 +7,7 @@ pluralizeListTitles =   "false"
 ignoreFiles = ["\\.Rmd$", "_files$", "_cache$"]
 canonifyurls = true
 # Enable Google Analytics by entering your tracking id
-googleAnalytics = "UA-20375833-20"
+googleAnalytics = "UA-20375833-3"
 [params]
 	author = "RStudio"
 	description = ""


### PR DESCRIPTION
@blairj09 
I’ve replaced your Google Analytics tracking number with the one for rstudio.com, which enables us to track users across domains.  Your site’s analytics will now be found under the rstudio.com property and I have built a segment for you to view your site’s metrics separate from other domains.  Data will populate from today forward and you will need to visit your previous property for historical data.  Thank you for merging this pull request so that we can get a full picture of online user behavior.